### PR TITLE
Fix: Make hero section scrollable

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,20 +44,20 @@
                 </div>
             </div>
         </nav>
+    </header>
 
-        <div class="hero" id="home">
-            <div class="container">
-                <h1>Find Your Dream Home in Kenya</h1>
-                <p>Discover luxury properties across Nairobi, Mombasa, and beyond with our comprehensive e-commerce platform</p>
-                <div class="search-bar">
-                    <input type="text" placeholder="Location (e.g., Westlands, Karen)">
-                    <input type="text" placeholder="Property Type (Villa, Apartment)">
-                    <input type="text" placeholder="Price Range (e.g., 10M-50M KES)">
-                    <button>Search Properties</button>
-                </div>
+    <div class="hero" id="home">
+        <div class="container">
+            <h1>Find Your Dream Home in Kenya</h1>
+            <p>Discover luxury properties across Nairobi, Mombasa, and beyond with our comprehensive e-commerce platform</p>
+            <div class="search-bar">
+                <input type="text" placeholder="Location (e.g., Westlands, Karen)">
+                <input type="text" placeholder="Property Type (Villa, Apartment)">
+                <input type="text" placeholder="Price Range (e.g., 10M-50M KES)">
+                <button>Search Properties</button>
             </div>
         </div>
-    </header>
+    </div>
 
     <main>
         <section class="featured-properties" id="properties">


### PR DESCRIPTION
The hero section was placed inside the `<header>` element, which has a fixed position. This caused the hero section to be fixed as well, preventing you from scrolling down to see the rest of the page content.

This change moves the hero section out of the `<header>` element, making it scrollable with the rest of the page.